### PR TITLE
Build platform-independent CXFrameworks with Carthage

### DIFF
--- a/src/Cartfile.resolved
+++ b/src/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "boken-engine/boken-engine" "81059f3221045e0f8b6cf90e2645a3e274a222a1"
+github "boken-engine/boken-engine" "80bf6c36330b087a2c5dd629fc97e421b18e3ad6"

--- a/src/Iakkai Saga - The Curse of Blood.xcodeproj/project.pbxproj
+++ b/src/Iakkai Saga - The Curse of Blood.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -62,34 +62,18 @@
 		5DE49E5D2697185D0009C301 /* map-travel.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5DE49E232697185D0009C301 /* map-travel.jpg */; };
 		5DE49E5F2697185D0009C301 /* wolfsteps.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5DE49E252697185D0009C301 /* wolfsteps.jpg */; };
 		5DE49E612697185D0009C301 /* contact-sheet.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5DE49E272697185D0009C301 /* contact-sheet.jpg */; };
-		A4FB4FC726C68EDD006E4A25 /* BokenEngine.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A4FB4FC126C68D1F006E4A25 /* BokenEngine.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A489142226CD6BAE00A2CD52 /* BokenEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A489142126CD6BAE00A2CD52 /* BokenEngine.framework */; };
+		A489142326CD6BAE00A2CD52 /* BokenEngine.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A489142126CD6BAE00A2CD52 /* BokenEngine.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		A4FB4FC026C68D1F006E4A25 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A4FB4FBB26C68D1F006E4A25 /* BokenEngine.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 5D0DF6EB25B056B80099F811;
-			remoteInfo = BokenEngine;
-		};
-		A4FB4FC226C68D1F006E4A25 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = A4FB4FBB26C68D1F006E4A25 /* BokenEngine.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 5D0DF6F425B056B90099F811;
-			remoteInfo = BokenEngineTests;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXCopyFilesBuildPhase section */
-		A4FB4FC626C68D91006E4A25 /* Embed Frameworks */ = {
+		A489142426CD6BAE00A2CD52 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 12;
+			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				A4FB4FC726C68EDD006E4A25 /* BokenEngine.framework in Embed Frameworks */,
+				A489142326CD6BAE00A2CD52 /* BokenEngine.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -154,9 +138,11 @@
 		5DE49E232697185D0009C301 /* map-travel.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "map-travel.jpg"; sourceTree = "<group>"; };
 		5DE49E252697185D0009C301 /* wolfsteps.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = wolfsteps.jpg; sourceTree = "<group>"; };
 		5DE49E272697185D0009C301 /* contact-sheet.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "contact-sheet.jpg"; sourceTree = "<group>"; };
+		A489141F26CD6AAE00A2CD52 /* BokenEngine.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BokenEngine.framework; path = "Carthage/Build/BokenEngine.xcframework/ios-arm64_x86_64-simulator/BokenEngine.framework"; sourceTree = "<group>"; };
+		A489142126CD6BAE00A2CD52 /* BokenEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BokenEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A4E4A66126C536900017110F /* Iakkai Saga - The Curse of Blood.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Iakkai Saga - The Curse of Blood.entitlements"; sourceTree = "<group>"; };
 		A4FB4FBA26C68BB3006E4A25 /* boken-engine */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "boken-engine"; path = "../../boken-engine"; sourceTree = "<group>"; };
-		A4FB4FBB26C68D1F006E4A25 /* BokenEngine.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BokenEngine.xcodeproj; path = "../../boken-engine/BokenEngine.xcodeproj"; sourceTree = "<group>"; };
+		A4FB4FBB26C68D1F006E4A25 /* BokenEngine.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BokenEngine.xcodeproj; path = "../../boken-engine/BokenEngine.xcodeproj"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +150,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A489142226CD6BAE00A2CD52 /* BokenEngine.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -173,6 +160,7 @@
 		5DA305502696DA9D007A51CE = {
 			isa = PBXGroup;
 			children = (
+				A489141F26CD6AAE00A2CD52 /* BokenEngine.framework */,
 				5DA3055B2696DA9E007A51CE /* Iakkai Saga - The Curse of Blood */,
 				5DA3055A2696DA9E007A51CE /* Products */,
 				A4FB4FB926C68BB3006E4A25 /* Frameworks */,
@@ -270,20 +258,12 @@
 		A4FB4FB926C68BB3006E4A25 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A489142126CD6BAE00A2CD52 /* BokenEngine.framework */,
 				A4FB4FBB26C68D1F006E4A25 /* BokenEngine.xcodeproj */,
 				A4FB4FBA26C68BB3006E4A25 /* boken-engine */,
 			);
 			name = Frameworks;
 			sourceTree = SOURCE_ROOT;
-		};
-		A4FB4FBC26C68D1F006E4A25 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				A4FB4FC126C68D1F006E4A25 /* BokenEngine.framework */,
-				A4FB4FC326C68D1F006E4A25 /* BokenEngineTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
@@ -295,7 +275,7 @@
 				5DA305552696DA9E007A51CE /* Sources */,
 				5DA305562696DA9E007A51CE /* Frameworks */,
 				5DA305572696DA9E007A51CE /* Resources */,
-				A4FB4FC626C68D91006E4A25 /* Embed Frameworks */,
+				A489142426CD6BAE00A2CD52 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -326,7 +306,7 @@
 				};
 			};
 			buildConfigurationList = 5DA305542696DA9D007A51CE /* Build configuration list for PBXProject "Iakkai Saga - The Curse of Blood" */;
-			compatibilityVersion = "Xcode 9.3";
+			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -336,35 +316,12 @@
 			mainGroup = 5DA305502696DA9D007A51CE;
 			productRefGroup = 5DA3055A2696DA9E007A51CE /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = A4FB4FBC26C68D1F006E4A25 /* Products */;
-					ProjectRef = A4FB4FBB26C68D1F006E4A25 /* BokenEngine.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				5DA305582696DA9E007A51CE /* Iakkai Saga - The Curse of Blood */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		A4FB4FC126C68D1F006E4A25 /* BokenEngine.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = BokenEngine.framework;
-			remoteRef = A4FB4FC026C68D1F006E4A25 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		A4FB4FC326C68D1F006E4A25 /* BokenEngineTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = BokenEngineTests.xctest;
-			remoteRef = A4FB4FC226C68D1F006E4A25 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		5DA305572696DA9E007A51CE /* Resources */ = {

--- a/src/Iakkai Saga - The Curse of Blood.xcodeproj/xcshareddata/xcschemes/Iakkai Saga - The Curse of Blood.xcscheme
+++ b/src/Iakkai Saga - The Curse of Blood.xcodeproj/xcshareddata/xcschemes/Iakkai Saga - The Curse of Blood.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5DA305582696DA9E007A51CE"
+               BuildableName = "Iakkai Saga - The Curse of Blood.app"
+               BlueprintName = "Iakkai Saga - The Curse of Blood"
+               ReferencedContainer = "container:Iakkai Saga - The Curse of Blood.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5DA305582696DA9E007A51CE"
+            BuildableName = "Iakkai Saga - The Curse of Blood.app"
+            BlueprintName = "Iakkai Saga - The Curse of Blood"
+            ReferencedContainer = "container:Iakkai Saga - The Curse of Blood.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5DA305582696DA9E007A51CE"
+            BuildableName = "Iakkai Saga - The Curse of Blood.app"
+            BlueprintName = "Iakkai Saga - The Curse of Blood"
+            ReferencedContainer = "container:Iakkai Saga - The Curse of Blood.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
I had a discussion with @yeraydavidrodriguez about hot we should link the Iakkai project with the Boken Engine framework.

We decided that:

- Iakkai should be easy to install in your local machine. The goal of this demo is not to be a scaffolding project you can use where you are developing new features for Boken Engine. You can set up a different configuration if you want that.
- We use package managers to install the Boken Engine. For example, using Carthage, you only need to run `carthage build --use-xcframeworks` after clonning the project.
- We had some errors trying to build the application without using a simulator. In fact, when we tried to generate the distribution for the Apple Store or running the macOS version locally.
![Screenshot 2021-08-18 at 17 37 43](https://user-images.githubusercontent.com/58816/129937465-155db94c-c9ba-4fa8-a1db-4f1fb1fbd953.png)

This PR should fix those problems.
